### PR TITLE
 feat: enable forceIndexFileImport option 

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,49 +1,53 @@
 module.exports = {
-    "env": {
-        "browser": true,
-        "es2021": true
+  "env": {
+    "browser": true,
+    "es2021": true,
+  },
+  "overrides": [],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module",
+  },
+  "settings": {
+    "import/resolver": {
+      typescript: true,
+      node: true,
     },
-    "overrides": [],
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-        "ecmaVersion": "latest",
-        "sourceType": "module"
+    "node": {
+      "resolvePaths": ["node_modules/@types"],
+      // "tryExtensions": [".js", ".json", ".node", ".ts", ".d.ts", ".cjs", ".mjs", ".mts", "cts"]
     },
-    "settings": {
-        "import/resolver": {
-            typescript: true,
-            node: true
-        },
-        "node": {
-            "resolvePaths": ["node_modules/@types"]
-            // "tryExtensions": [".js", ".json", ".node", ".ts", ".d.ts", ".cjs", ".mjs", ".mts", "cts"]
-        }
-    },
-    
-    "plugins": [
-        "node",
-        "import",
-        "unicorn",
-        "file-extension-in-import-ts"
+  },
+
+  "plugins": [
+    "node",
+    "import",
+    "unicorn",
+    "file-extension-in-import-ts",
+  ],
+  "rules": {
+    // https://github.com/AlexSergey/eslint-plugin-file-extension-in-import-ts
+    "file-extension-in-import-ts/file-extension-in-import-ts": [
+      "error",
+      "always",
+      { extMapping: { ".ts": ".js", forceIndexFileImport: true } },
     ],
-    "rules": {
-        // https://github.com/AlexSergey/eslint-plugin-file-extension-in-import-ts
-        "file-extension-in-import-ts/file-extension-in-import-ts": "error",
-        // https://github.com/mysticatea/eslint-plugin-node
-        // this plugin does not allow ".js" from ts?
-        // "node/no-missing-import": "error",
-        "node/no-extraneous-import": "error",
-        "node/no-sync": "warn",
-        "node/file-extension-in-import": "error",
-        // https://github.com/import-js/eslint-plugin-import
-        "import/extensions": "error",
-        "import/no-unresolved": "error",
-        "import/no-useless-path-segments": "error",
-        "import/no-extraneous-dependencies": "error",
-        "import/no-commonjs": "error",
-        // https://github.com/sindresorhus/eslint-plugin-unicorn
-        "unicorn/prefer-module": "error",
-        "unicorn/prefer-node-protocol": "error",
-        "unicorn/prefer-top-level-await": "error"
-    }
+    // https://github.com/mysticatea/eslint-plugin-node
+    // this plugin does not allow ".js" from ts?
+    // "node/no-missing-import": "error",
+    "node/no-extraneous-import": "error",
+    "node/no-sync": "warn",
+    "node/file-extension-in-import": "error",
+    // https://github.com/import-js/eslint-plugin-import
+    "import/extensions": "error",
+    "import/no-unresolved": "error",
+    "import/no-useless-path-segments": "error",
+    "import/no-extraneous-dependencies": "error",
+    "import/no-commonjs": "error",
+    // https://github.com/sindresorhus/eslint-plugin-unicorn
+    "unicorn/prefer-module": "error",
+    "unicorn/prefer-node-protocol": "error",
+    "unicorn/prefer-top-level-await": "error",
+  },
 };

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -31,7 +31,7 @@ module.exports = {
     "file-extension-in-import-ts/file-extension-in-import-ts": [
       "error",
       "always",
-      { extMapping: { ".ts": ".js", forceIndexFileImport: true } },
+      { extMapping: { ".ts": ".js" }, forceIndexFileImport: true },
     ],
     // https://github.com/mysticatea/eslint-plugin-node
     // this plugin does not allow ".js" from ts?

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ESLint wrapper for migration from CJS to ESM.
 
-This tool main use-case is to migrate from CommonJS(JavaScript/TypeScript) to ES Modules(JavaScript/TypeScript).
+This tool's main use-case is to migrate from CommonJS (JavaScript/TypeScript) to ES Modules (JavaScript/TypeScript).
 
 This tool is a wrapper of ESLint, and it built-in some rules for migration.
 So, you can just use this tool without any configuration.
@@ -15,9 +15,10 @@ Install with [npm](https://www.npmjs.com/package/eslint-cjs-to-esm):
 
 ## Usage
 
-Command Line Arguments is same to ESLint.
+Command Line Arguments are the same as those of ESLint.
 
     npx eslint-cjs-to-esm [ESLint Arguments!]
+
 
 - [Command Line Interface - ESLint - Pluggable JavaScript Linter](https://eslint.org/docs/latest/use/command-line-interface)
 

--- a/test-fixtures/dir/index.ts
+++ b/test-fixtures/dir/index.ts
@@ -1,0 +1,1 @@
+export const indexValue = 'index-value';

--- a/test-fixtures/import-index.ts
+++ b/test-fixtures/import-index.ts
@@ -1,0 +1,1 @@
+import {indexValue} from "./dir";


### PR DESCRIPTION
Add new autofix for import index.

```diff
- import index from "./dir"
+ import index from "./dir/index.js"
```

- Usage: https://github.com/AlexSergey/eslint-plugin-file-extension-in-import-ts/pull/8